### PR TITLE
fix: remove npm image tags, do it after first publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # LINE Blockchain Developers SDK for JavaScript
-[![NPM version](https://img.shields.io/npm/v/%40line%2Fline-blockchain-developers-sdk-js
-.svg)](https://www.npmjs.com/package/@line/line-blockchain-developers-sdk-js
-)
-[![NPM downloads](https://img.shields.io/npm/dm/%40line%2Fline-blockchain-developers-sdk-js
-.svg)](https://www.npmjs.com/package/@line/line-blockchain-developers-sdk-js)
+<!-- 
+//TODO add npm version, downloads, build status and etc, after release
+-->
 
 ## Table of Contents // TODO update
 * [Introduction](#introduction)


### PR DESCRIPTION
### What kind of change does this PR introduce?
* document: remove npm tags from readme, add them after first publish