### PR TITLE
fix: wrong type(String) to correct type(string)

### DIFF
--- a/lib/response.ts
+++ b/lib/response.ts
@@ -112,7 +112,7 @@ export class LogResponse {
 export class EventResponse {
   constructor(
     readonly type: string,
-    readonly attributes: Array<KeyValueResponse<String>>,
+    readonly attributes: Array<KeyValueResponse<string>>,
   ) { }
 }
 
@@ -120,7 +120,7 @@ export class KeyValueResponse<T> {
   constructor(readonly key: string, readonly value?: T) { }
 }
 export class TypedValueResponse<T> {
-  constructor(readonly type: String, readonly value: T) { }
+  constructor(readonly type: string, readonly value: T) { }
 }
 
 export class StdTxResponse {
@@ -152,8 +152,8 @@ export class BaseCoinBalance {
 
 export class CoinResponse {
   constructor(readonly denom: string, readonly amount: BigInt) { }
-  toString(): String {
-    return this.amount.toString() + this.denom;
+  tostring(): string {
+    return this.amount.tostring() + this.denom;
   }
 }
 

--- a/lib/response.ts
+++ b/lib/response.ts
@@ -152,8 +152,8 @@ export class BaseCoinBalance {
 
 export class CoinResponse {
   constructor(readonly denom: string, readonly amount: BigInt) { }
-  tostring(): string {
-    return this.amount.tostring() + this.denom;
+  toString(): string {
+    return this.amount.toString() + this.denom;
   }
 }
 


### PR DESCRIPTION
### What kind of change does this PR introduce? 
* [o] bug fix
  - there was wrong type used, which is `String`, but in typescript `string` is correct type.  

### What is the current behavior? 
There will an error get string value from tx-result response.

### What is the new behavior?
without any type error from getting value from tx-result response.
