### PR TITLE
fix UserIdAddress type address -> walletAddress

### DIFF
--- a/lib/response.ts
+++ b/lib/response.ts
@@ -303,7 +303,7 @@ export class NonFungibleTokenHolder {
 }
 
 export class UserIdAddress {
-  constructor(readonly userId: string, readonly address: string) { }
+  constructor(readonly userId: string, readonly walletAddress: string) { }
 }
 export class SessionTokenResponse {
   constructor(


### PR DESCRIPTION
### What kind of change does this PR introduce? 
* [x] bug fix
* [ ] feature
* [ ] docs
* [ ] update

### Other information
Looking at [this document](https://docs-blockchain.line.biz/api-guide/category-users), it seems that UserIdAddress is not 'address' but 'walletAddress'.