### PR TITLE
fix: correct required parameter to optional one

### DIFF
--- a/lib/request.ts
+++ b/lib/request.ts
@@ -287,7 +287,7 @@ export class NonFungibleTokenMintRequest extends AbstractTransactionRequest {
     readonly ownerAddress: string,
     readonly ownerSecret: string,
     readonly name: string,
-    readonly meta: string,
+    readonly meta?: string,
     toAddress?: string,
     toUserId?: string,
   ) {


### PR DESCRIPTION
### What kind of change does this PR introduce? 
* [x] bug fix
* [ ] feature
* [ ] docs
* [ ] update

### What is the current behavior? 
According to [official API docs](https://docs-blockchain.line.biz/ja/api-guide/category-item-tokens/mint-burn#v1-item-tokens-contractId-non-fungibles-tokenType-mint-post), the meta parameter is optional, but the implementation is a required parameter.

### What is the new behavior?
Correct required parameter to optional one.
