### PR TITLE
fix: #39 validation token-type

### DIFF
--- a/lib/request.ts
+++ b/lib/request.ts
@@ -208,7 +208,7 @@ export class MultiNonFungibleTokenMediaResourcesUpdateRequest {
 
 export class TokenType {
   private constructor(readonly tokenType: string) { }
-  static readonly tokenTypeFormat = new RegExp("\\d{8}");
+  static readonly tokenTypeFormat = new RegExp("\\w{8}");
   static readonly tokenTypeLength = 8;
   static from(value: string): TokenType {
     if (value.length != TokenType.tokenTypeLength) {


### PR DESCRIPTION
### What kind of change does this PR introduce? 
* [O] bug fix: #39 

### What is the current behavior? 
Validate `token-type` with RegEx -`\d{8}`

### What is the new behavior?
Validate `token-type` with RegEx -`\w{8}`
