### PR TITLE
feat, fix: add txResultCode

### DIFF
--- a/lib/transaction-message-parser.ts
+++ b/lib/transaction-message-parser.ts
@@ -1,6 +1,7 @@
 import { GenericResponse, TxResultResponse } from "./response";
 import { TxResultUtil } from "./tx-result-util";
 import { TokenUtil } from "./token-util";
+import { TxResultCodeMappingsProvider } from "./tx-result-codes";
 import {
   MessageType,
   TxResultMessage,
@@ -40,9 +41,7 @@ import {
 // TODO this interface, and just parse directly
 export interface TxResultMessageParser<T extends TxResultMessage> {
   parse(txResultResponse: TxResultResponse): T;
-  parseGenericTxResultResponse(
-    txResultResponse: GenericResponse<TxResultResponse>,
-  ): T;
+  parseGenericTxResultResponse(txResultResponse: GenericResponse<TxResultResponse>): T;
 }
 
 export class ServiceTokenIssueMessageParser
@@ -62,6 +61,7 @@ export class ServiceTokenIssueMessageParser
     txResultResponse: TxResultResponse,
   ): ServiceTokenIssueMessage {
     return new ServiceTokenIssueMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findOwnerWalletAddress(txResultResponse),
@@ -90,6 +90,7 @@ export class ServiceTokenModifyMessageParser
     txResultResponse: TxResultResponse,
   ): ServiceTokenModifyMessage {
     return new ServiceTokenModifyMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findSenderWalletAddress(txResultResponse),
@@ -117,6 +118,7 @@ export class ServiceTokenMintMessageParser
     txResultResponse: TxResultResponse,
   ): ServiceTokenMintMessage {
     return new ServiceTokenMintMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findFromWalletAddress(txResultResponse),
@@ -145,6 +147,7 @@ export class ServiceTokenBurnMessageParser
     txResultResponse: TxResultResponse,
   ): ServiceTokenBurnMessage {
     return new ServiceTokenBurnMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findFromWalletAddress(txResultResponse),
@@ -172,6 +175,7 @@ export class ServiceTokenBurnFromMessageParser
     txResultResponse: TxResultResponse,
   ): ServiceTokenBurnFromMessage {
     return new ServiceTokenBurnFromMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findFromWalletAddress(txResultResponse),
@@ -199,6 +203,7 @@ export class ServiceTokenTransferMessageParser
     txResultResponse: TxResultResponse,
   ): ServiceTokenTransferMessage {
     return new ServiceTokenTransferMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findFromWalletAddress(txResultResponse),
@@ -227,6 +232,7 @@ export class ServiceTokenTransferFromMessageParser
     txResultResponse: TxResultResponse,
   ): ServiceTokenTransferFromMessage {
     return new ServiceTokenTransferFromMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findFromWalletAddress(txResultResponse),
@@ -256,6 +262,7 @@ export class ServiceTokenApprovedMessageParser
     txResultResponse: TxResultResponse,
   ): ServiceTokenApprovedMessage {
     return new ServiceTokenApprovedMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findSenderWalletAddress(txResultResponse),
@@ -283,6 +290,7 @@ export class ItemTokenCreateMessageParser
     txResultResponse: TxResultResponse,
   ): ItemTokenCreateMessage {
     return new ItemTokenCreateMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       // TxResultUtil.findFromWalletAddress(txResultResponse),
@@ -313,6 +321,7 @@ export class ItemTokenModifyMessageParser
     const isFungible = TokenUtil.isFungible(tokenType);
     const tokenId = TxResultUtil.findTokenId(txResultResponse);
     return new ItemTokenModifyMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findFromWalletAddress(txResultResponse),
@@ -345,6 +354,7 @@ export class ItemTokenApproveMessageParser
     txResultResponse: TxResultResponse,
   ): ItemTokenApproveMessage {
     return new ItemTokenApproveMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findFromWalletAddress(txResultResponse),
@@ -372,6 +382,7 @@ export class ItemTokenDisapproveMessageParser
     txResultResponse: TxResultResponse,
   ): ItemTokenDisapproveMessage {
     return new ItemTokenDisapproveMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findFromWalletAddress(txResultResponse),
@@ -405,6 +416,7 @@ export class NFTAttachMessageParser
     const tokenId = TxResultUtil.findTokenId(txResultResponse);
     const tokenIndex = TokenUtil.tokenIndexFrom(tokenId);
     return new NonFungibleTokenAttachMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findFromWalletAddress(txResultResponse),
@@ -438,6 +450,7 @@ export class NFTAttachFromMessageParser
     const tokenId = TxResultUtil.findTokenId(txResultResponse);
     const tokenIndex = TokenUtil.tokenIndexFrom(tokenId);
     return new NonFungibleTokenAttachFromMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findFromWalletAddress(txResultResponse),
@@ -474,6 +487,7 @@ export class NFTDetachMessageParser
     const tokenId = TxResultUtil.findTokenId(txResultResponse);
     const tokenIndex = TokenUtil.tokenIndexFrom(tokenId);
     return new NonFungibleTokenDetachMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findFromWalletAddress(txResultResponse),
@@ -509,6 +523,7 @@ export class NFTDetachFromMessageParser
     const tokenId = TxResultUtil.findTokenId(txResultResponse);
     const tokenIndex = TokenUtil.tokenIndexFrom(tokenId);
     return new NonFungibleTokenDetachFromMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findFromWalletAddress(txResultResponse),
@@ -539,6 +554,7 @@ export class IssueFungibleMessageParser
     const tokenId = TxResultUtil.findTokenIdFromEvents(txResultResponse);
     const tokenType = TokenUtil.tokenTypeFrom(tokenId);
     return new FungibleTokenIssueMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findSenderWalletAddress(txResultResponse),
@@ -570,6 +586,7 @@ export class MintFungibleMessageParser
       txResultResponse,
     );
     return new FungibleTokenMintMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findFromWalletAddress(txResultResponse),
@@ -599,6 +616,7 @@ export class BurnFungibleMessageParser
       txResultResponse,
     );
     return new FungibleTokenBurnMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findFromWalletAddress(txResultResponse),
@@ -625,6 +643,7 @@ export class FungibleTransferMessageParser
     txResultResponse: TxResultResponse,
   ): FungibleTokenTransferMessage {
     return new FungibleTokenTransferMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findFromWalletAddress(txResultResponse),
@@ -652,6 +671,7 @@ export class FungibleTransferFromMessageParser
     txResultResponse: TxResultResponse,
   ): FungibleTokenTransferFromMessage {
     return new FungibleTokenTransferFromMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findFromWalletAddress(txResultResponse),
@@ -683,6 +703,7 @@ export class BurnFromFungibleMessageParser
       txResultResponse,
     );
     return new FungibleTokenBurnFromMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findFromWalletAddress(txResultResponse),
@@ -710,6 +731,7 @@ export class NonFungibleTokenIssueMessageParser
     txResultResponse: TxResultResponse,
   ): NonFungibleTokenIssueMessage {
     return new NonFungibleTokenIssueMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findSenderWalletAddress(txResultResponse),
@@ -736,6 +758,7 @@ export class NonFungibleTokenMintMessageParser
     txResultResponse: TxResultResponse,
   ): NonFungibleTokenMintMessage {
     return new NonFungibleTokenMintMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       "",
@@ -761,6 +784,7 @@ export class NonFungibleTokenBurnMessageParser
     txResultResponse: TxResultResponse,
   ): NonFungibleTokenBurnMessage {
     return new NonFungibleTokenBurnMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findFromWalletAddress(txResultResponse),
@@ -788,6 +812,7 @@ export class NonFungibleTokenBurnFromMessageParser
     txResultResponse: TxResultResponse,
   ): NonFungibleTokenBurnFromMessage {
     return new NonFungibleTokenBurnFromMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findFromWalletAddress(txResultResponse),
@@ -815,6 +840,7 @@ export class NonFungibleTokenTransferMessageParser
     txResultResponse: TxResultResponse,
   ): NonFungibleTokenTransferMessage {
     return new NonFungibleTokenTransferMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findFromWalletAddress(txResultResponse),
@@ -842,6 +868,7 @@ export class NonFungibleTokenTransferFromMessageParser
     txResultResponse: TxResultResponse,
   ): NonFungibleTokenTransferFromMessage {
     return new NonFungibleTokenTransferFromMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findFromWalletAddress(txResultResponse),
@@ -868,6 +895,7 @@ export class BaseCoinSendMessageParser
     txResultResponse: TxResultResponse,
   ): BaseCoinTransferMessage {
     return new BaseCoinTransferMessage(
+      TxResultCodeMappingsProvider.code(txResultResponse),
       txResultResponse.height,
       txResultResponse.txhash,
       TxResultUtil.findFromWalletAddress(txResultResponse),

--- a/lib/transaction-messages.ts
+++ b/lib/transaction-messages.ts
@@ -1,3 +1,5 @@
+import { TxResultCode } from "./tx-result-codes";
+
 export enum MessageType {
   // SERVICE TOKEN MESSAGE TYPES
   SERVICE_TOKEN_ISSUE = "token/MsgIssue",
@@ -41,11 +43,12 @@ export enum MessageType {
 
 export abstract class TxResultMessage {
   constructor(
+    readonly txResultCode: TxResultCode,
     readonly height: number,
     readonly txHash: string,
     readonly from: string,
     readonly proxy?: string, // transaction come from proxy wallet
-  ) {}
+  ) { }
 
   isProxyTransaction(): boolean {
     return !!this.proxy;
@@ -60,7 +63,7 @@ export class IssuedServiceToken {
     readonly meta: string,
     readonly imUri: string,
     readonly decimal: number,
-  ) {}
+  ) { }
 }
 
 export class CreatedItemToken {
@@ -70,11 +73,11 @@ export class CreatedItemToken {
     readonly name: string,
     readonly meta: string,
     readonly baseImgUri: string,
-  ) {}
+  ) { }
 }
 
 export class FungibleToken {
-  constructor(readonly contractId: string, readonly tokenType: string) {}
+  constructor(readonly contractId: string, readonly tokenType: string) { }
 }
 
 export class IssuedFungibleToken extends FungibleToken {
@@ -112,11 +115,11 @@ export class NonFungibleToken {
     readonly contractId: string,
     readonly tokenType: string,
     readonly tokenIndex?: string,
-  ) {}
+  ) { }
 }
 
 export class BaseCoinAmount {
-  constructor(readonly contractId: string, readonly amount: string) {}
+  constructor(readonly contractId: string, readonly amount: string) { }
 }
 
 export class IssuedNonFungibleToken extends NonFungibleToken {
@@ -156,11 +159,12 @@ export class TransferredNonFungibleToken extends NonFungibleToken {
 }
 
 export class TokenChange {
-  constructor(readonly field: string, readonly value: string) {}
+  constructor(readonly field: string, readonly value: string) { }
 }
 
 export class ServiceTokenIssueMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
@@ -169,12 +173,13 @@ export class ServiceTokenIssueMessage extends TxResultMessage {
     readonly issuedServiceToken: IssuedServiceToken,
     readonly amount: string,
   ) {
-    super(height, txHash, from);
+    super(txResultCode, height, txHash, from);
   }
 }
 
 export class ServiceTokenModifyMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     sender: string, // sender
@@ -182,12 +187,13 @@ export class ServiceTokenModifyMessage extends TxResultMessage {
     readonly contractId: string,
     readonly changes: Array<TokenChange>,
   ) {
-    super(height, txHash, sender);
+    super(txResultCode, height, txHash, sender);
   }
 }
 
 export class ServiceTokenMintMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
@@ -196,12 +202,13 @@ export class ServiceTokenMintMessage extends TxResultMessage {
     readonly contractId: string,
     readonly amount: string,
   ) {
-    super(height, txHash, from);
+    super(txResultCode, height, txHash, from);
   }
 }
 
 export class ServiceTokenBurnMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
@@ -209,12 +216,13 @@ export class ServiceTokenBurnMessage extends TxResultMessage {
     readonly contractId: string,
     readonly amount: string,
   ) {
-    super(height, txHash, from);
+    super(txResultCode, height, txHash, from);
   }
 }
 
 export class ServiceTokenBurnFromMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
@@ -222,12 +230,13 @@ export class ServiceTokenBurnFromMessage extends TxResultMessage {
     readonly contractId: string,
     readonly amount: string,
   ) {
-    super(height, txHash, from);
+    super(txResultCode, height, txHash, from);
   }
 }
 
 export class ServiceTokenGrantPermissionMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
@@ -236,12 +245,13 @@ export class ServiceTokenGrantPermissionMessage extends TxResultMessage {
     readonly to: string,
     readonly permission: string,
   ) {
-    super(height, txHash, from);
+    super(txResultCode, height, txHash, from);
   }
 }
 
 export class ServiceTokenRevokePermissionMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
@@ -249,12 +259,13 @@ export class ServiceTokenRevokePermissionMessage extends TxResultMessage {
     readonly contractId: string,
     readonly permission: string,
   ) {
-    super(height, txHash, from);
+    super(txResultCode, height, txHash, from);
   }
 }
 
 export class ServiceTokenTransferMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
@@ -263,12 +274,13 @@ export class ServiceTokenTransferMessage extends TxResultMessage {
     readonly to: string,
     readonly amount: string,
   ) {
-    super(height, txHash, from);
+    super(txResultCode, height, txHash, from);
   }
 }
 
 export class ServiceTokenTransferFromMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
@@ -278,12 +290,13 @@ export class ServiceTokenTransferFromMessage extends TxResultMessage {
     readonly to: string,
     readonly amount: string,
   ) {
-    super(height, txHash, from, proxy);
+    super(txResultCode, height, txHash, from, proxy);
   }
 }
 
 export class ServiceTokenApprovedMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     readonly sender: string,
@@ -291,23 +304,25 @@ export class ServiceTokenApprovedMessage extends TxResultMessage {
     readonly approver: string,
     readonly contractId: string,
   ) {
-    super(height, txHash, sender, proxy);
+    super(txResultCode, height, txHash, sender, proxy);
   }
 }
 
 export class ItemTokenCreateMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     readonly sender: string,
     readonly createdItemToken: CreatedItemToken,
   ) {
-    super(height, txHash, sender);
+    super(txResultCode, height, txHash, sender);
   }
 }
 
 export class ItemTokenModifyMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string, // sender
@@ -320,7 +335,7 @@ export class ItemTokenModifyMessage extends TxResultMessage {
     readonly changes: Array<TokenChange>,
     readonly isFungible: boolean = false,
   ) {
-    super(height, txHash, from);
+    super(txResultCode, height, txHash, from);
     if (!this.tokenId || this.tokenId.length < 1) {
       this.tokenId = `${tokenType}${tokenIndex}`;
     }
@@ -329,6 +344,7 @@ export class ItemTokenModifyMessage extends TxResultMessage {
 
 export class ItemTokenApproveMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
@@ -336,12 +352,13 @@ export class ItemTokenApproveMessage extends TxResultMessage {
     readonly contractId: string,
     readonly proxy: string, // approve to
   ) {
-    super(height, txHash, from);
+    super(txResultCode, height, txHash, from);
   }
 }
 
 export class ItemTokenDisapproveMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
@@ -349,12 +366,13 @@ export class ItemTokenDisapproveMessage extends TxResultMessage {
     readonly contractId: string,
     readonly proxy: string,
   ) {
-    super(height, txHash, from);
+    super(txResultCode, height, txHash, from);
   }
 }
 
 export class ItemTokenGrantPermissionMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
@@ -363,12 +381,13 @@ export class ItemTokenGrantPermissionMessage extends TxResultMessage {
     readonly to: string,
     readonly permission: string,
   ) {
-    super(height, txHash, from);
+    super(txResultCode, height, txHash, from);
   }
 }
 
 export class ItemTokenRevokePermissionMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
@@ -376,12 +395,13 @@ export class ItemTokenRevokePermissionMessage extends TxResultMessage {
     readonly contractId: string,
     readonly permission: string,
   ) {
-    super(height, txHash, from);
+    super(txResultCode, height, txHash, from);
   }
 }
 
 export class FungibleTokenIssueMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     readonly sender: string,
@@ -390,12 +410,13 @@ export class FungibleTokenIssueMessage extends TxResultMessage {
     readonly issuedFungibleToken: IssuedFungibleToken,
     readonly amount: string,
   ) {
-    super(height, txHash, sender);
+    super(txResultCode, height, txHash, sender);
   }
 }
 
 export class FungibleTokenModifyMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
@@ -404,12 +425,13 @@ export class FungibleTokenModifyMessage extends TxResultMessage {
     readonly tokenType: string,
     readonly changes: Array<TokenChange>,
   ) {
-    super(height, txHash, from);
+    super(txResultCode, height, txHash, from);
   }
 }
 
 export class FungibleTokenMintMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
@@ -417,12 +439,13 @@ export class FungibleTokenMintMessage extends TxResultMessage {
     readonly to: string, // receiver
     readonly mintedFungibleTokens: Array<MintedFungibleToken>,
   ) {
-    super(height, txHash, from);
+    super(txResultCode, height, txHash, from);
   }
 }
 
 export class FungibleTokenBurnMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
@@ -430,12 +453,13 @@ export class FungibleTokenBurnMessage extends TxResultMessage {
     readonly contractId: string,
     readonly burnedFungibleTokens: Array<BurnedFungibleToken>,
   ) {
-    super(height, txHash, from);
+    super(txResultCode, height, txHash, from);
   }
 }
 
 export class FungibleTokenBurnFromMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
@@ -443,12 +467,13 @@ export class FungibleTokenBurnFromMessage extends TxResultMessage {
     readonly contractId: string,
     readonly burnedFungibleTokens: Array<BurnedFungibleToken>,
   ) {
-    super(height, txHash, from, proxy);
+    super(txResultCode, height, txHash, from, proxy);
   }
 }
 
 export class FungibleTokenTransferMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
@@ -457,12 +482,13 @@ export class FungibleTokenTransferMessage extends TxResultMessage {
     readonly to: string,
     readonly transferredFungibleTokenAmount: TransferredFungibleTokenAmount,
   ) {
-    super(height, txHash, from);
+    super(txResultCode, height, txHash, from);
   }
 }
 
 export class FungibleTokenTransferFromMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
@@ -472,35 +498,38 @@ export class FungibleTokenTransferFromMessage extends TxResultMessage {
     readonly to: string,
     readonly transferredFungibleTokenAmount: TransferredFungibleTokenAmount,
   ) {
-    super(height, txHash, from, proxy);
+    super(txResultCode, height, txHash, from, proxy);
   }
 }
 
 export class NonFungibleTokenIssueMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     readonly sender: string,
     readonly contractId: string,
     readonly issuedNonFungibleToken: IssuedNonFungibleToken,
   ) {
-    super(height, txHash, sender);
+    super(txResultCode, height, txHash, sender);
   }
 }
 
 export class NonFungibleTokenMintMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string = "",
     readonly mintedNonFungibleTokens: Array<MintedNonFungibleToken>,
   ) {
-    super(height, txHash, from);
+    super(txResultCode, height, txHash, from);
   }
 }
 
 export class NonFungibleTokenBurnMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
@@ -508,12 +537,13 @@ export class NonFungibleTokenBurnMessage extends TxResultMessage {
     readonly contractId: string,
     readonly burnedNonFungibleToken: NonFungibleToken,
   ) {
-    super(height, txHash, from);
+    super(txResultCode, height, txHash, from);
   }
 }
 
 export class NonFungibleTokenBurnFromMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
@@ -522,35 +552,38 @@ export class NonFungibleTokenBurnFromMessage extends TxResultMessage {
     readonly contractId: string,
     readonly burnedNonFungibleToken: NonFungibleToken,
   ) {
-    super(height, txHash, from, proxy);
+    super(txResultCode, height, txHash, from, proxy);
   }
 }
 
 export class NonFungibleTokenTransferMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
     readonly transferredNonFungibleTokens: Array<NonFungibleToken>,
   ) {
-    super(height, txHash, from);
+    super(txResultCode, height, txHash, from);
   }
 }
 
 export class NonFungibleTokenTransferFromMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
     proxy: string,
     readonly transferredNonFungibleTokens: Array<NonFungibleToken>,
   ) {
-    super(height, txHash, from, proxy);
+    super(txResultCode, height, txHash, from, proxy);
   }
 }
 
 export class NonFungibleTokenAttachMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
@@ -558,12 +591,13 @@ export class NonFungibleTokenAttachMessage extends TxResultMessage {
     readonly parentNonFungibleToken: NonFungibleToken,
     readonly attachedNonFungibleToken: NonFungibleToken,
   ) {
-    super(height, txHash, from);
+    super(txResultCode, height, txHash, from);
   }
 }
 
 export class NonFungibleTokenAttachFromMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
@@ -572,12 +606,13 @@ export class NonFungibleTokenAttachFromMessage extends TxResultMessage {
     readonly parentNonFungibleToken: NonFungibleToken,
     readonly attachedNonFungibleToken: NonFungibleToken,
   ) {
-    super(height, txHash, from, proxy);
+    super(txResultCode, height, txHash, from, proxy);
   }
 }
 
 export class NonFungibleTokenDetachMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
@@ -585,12 +620,13 @@ export class NonFungibleTokenDetachMessage extends TxResultMessage {
     readonly parentNonFungibleToken: NonFungibleToken,
     readonly attachedNonFungibleToken: NonFungibleToken,
   ) {
-    super(height, txHash, from);
+    super(txResultCode, height, txHash, from);
   }
 }
 
 export class NonFungibleTokenDetachFromMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
@@ -599,12 +635,13 @@ export class NonFungibleTokenDetachFromMessage extends TxResultMessage {
     readonly parentNonFungibleToken: NonFungibleToken,
     readonly attachedNonFungibleToken: NonFungibleToken,
   ) {
-    super(height, txHash, from, proxy);
+    super(txResultCode, height, txHash, from, proxy);
   }
 }
 
 export class BaseCoinTransferMessage extends TxResultMessage {
   constructor(
+    txResultCode: TxResultCode,
     height: number,
     txHash: string,
     from: string,
@@ -612,6 +649,6 @@ export class BaseCoinTransferMessage extends TxResultMessage {
     readonly to: string,
     readonly baseCoinAmount: BaseCoinAmount,
   ) {
-    super(height, txHash, from);
+    super(txResultCode, height, txHash, from);
   }
 }

--- a/lib/tx-result-codes.ts
+++ b/lib/tx-result-codes.ts
@@ -1,0 +1,200 @@
+import { TxResultResponse } from "./response"
+const txResultCodeMappings =
+    [
+        {
+            "codespace": "bank",
+            "codes": [
+                { "code": 0, "description": "" },
+                { "code": 1, "description": "No \"inputs\" for \"send\" type transaction" },
+                { "code": 2, "description": "No \"outputs\" for \"send\" type transaction" },
+                { "code": 3, "description": "Sum \"inputs\" != sum \"outputs\"" },
+                { "code": 4, "description": "\"Send\" type transactions are disabled." }
+            ]
+        },
+        {
+            "codespace": "coin",
+            "codes": [
+                { "code": 0, "description": "" },
+                { "code": 1, "description": "No \"inputs\" for \"send\" type transaction" },
+                { "code": 2, "description": "No \"outputs\" for \"send\" type transaction" },
+                { "code": 3, "description": "Sum \"inputs\" != sum \"outputs\"" },
+                { "code": 4, "description": "\"Send\" type transactions are disabled." },
+                { "code": 5, "description": "Can't transfer to safety box addresses." },
+                { "code": 6, "description": "The number of addresses exceeded the limit." }
+            ]
+        },
+        {
+            "codespace": "collection",
+            "codes": [
+                { "code": 0, "description": "" },
+                { "code": 1, "description": "Token with the given token ID already exists in the contract." },
+                { "code": 2, "description": "Token with the given token ID doesn't exist in the contract." },
+                { "code": 3, "description": "Token with the given token ID in the contract isn't mintable." },
+                { "code": 4, "description": "Token name shouldn't be empty." },
+                { "code": 5, "description": "Invalid token ID" },
+                { "code": 6, "description": "Token decimals should be within the range in 0–18." },
+                { "code": 7, "description": "Issuing token with amount[1], decimals[0], mintable[false] prohibited. Issue non-fungible token instead." },
+                { "code": 8, "description": "Invalid token amount" },
+                { "code": 9, "description": "Invalid \"base_img_uri\" length" },
+                { "code": 10, "description": "Invalid \"name\" length" },
+                { "code": 11, "description": "Invalid token type pattern found." },
+                { "code": 12, "description": "Invalid token index pattern found." },
+                { "code": 13, "description": "Collection already exists." },
+                { "code": 14, "description": "Collection doesn't exist." },
+                { "code": 15, "description": "Token Type for the given contract ID already exists." },
+                { "code": 16, "description": "Token Type for the given contract ID doesn't exist." },
+                { "code": 17, "description": "All token types for the given contract ID are occupied." },
+                { "code": 18, "description": "All non-fungible token indices for contract ID and token type are occupied." },
+                { "code": 19, "description": "All fungible token IDs for contract ID are occupied." },
+                { "code": 20, "description": "Account doesn't have the permission." },
+                { "code": 21, "description": "Token is already a child of some other token." },
+                { "code": 22, "description": "Token isn't a child of some other token." },
+                { "code": 23, "description": "Token is being not owned." },
+                { "code": 24, "description": "Can't transfer a child token." },
+                { "code": 25, "description": "Token isn't a non-fungible token." },
+                { "code": 26, "description": "Can't attach token to itself." },
+                { "code": 27, "description": "Can't attach token to a descendant." },
+                { "code": 28, "description": "Approver is same as proxy." },
+                { "code": 29, "description": "Proxy isn't approved on the collection." },
+                { "code": 30, "description": "Proxy is already approved on the collection." },
+                { "code": 31, "description": "Account already exists." },
+                { "code": 32, "description": "Account doesn't exist." },
+                { "code": 33, "description": "Insufficient supply" },
+                { "code": 34, "description": "Invalid coin" },
+                { "code": 35, "description": "Invalid count of field \"changes\"" },
+                { "code": 36, "description": "\"changes\" is empty." },
+                { "code": 37, "description": "Invalid field of \"changes\"" },
+                { "code": 38, "description": "There is a token index but no token type." },
+                { "code": 39, "description": "There is a token type of FT but no token index." },
+                { "code": 40, "description": "Insufficient token" },
+                { "code": 41, "description": "Duplicate field of \"changes\"" },
+                { "code": 42, "description": "Invalid \"meta\" length" },
+                { "code": 43, "description": "Supply for collection reached maximum." },
+                { "code": 44, "description": "Required field can't be empty." },
+                { "code": 45, "description": "Can't attach token. (composition too deep)" },
+                { "code": 46, "description": "Can't attach token. (composition too wide)" }
+            ]
+        },
+        {
+            "codespace": "token",
+            "codes": [
+                { "code": 0, "description": "" },
+                { "code": 1, "description": "Token already exists." },
+                { "code": 2, "description": "Token doesn't exist." },
+                { "code": 3, "description": "Token isn't mintable." },
+                { "code": 4, "description": "Token name shouldn't be empty." },
+                { "code": 5, "description": "Token decimals should be within the range of 0–18." },
+                { "code": 6, "description": "Invalid token amount" },
+                { "code": 7, "description": "Invalid token URI length" },
+                { "code": 8, "description": "Invalid name length" },
+                { "code": 9, "description": "Invalid token symbol" },
+                { "code": 10, "description": "Account doesn't have the permission." },
+                { "code": 11, "description": "Account already exists." },
+                { "code": 12, "description": "Account doesn't exist." },
+                { "code": 13, "description": "Insufficient balance" },
+                { "code": 14, "description": "Supply for token already exists" },
+                { "code": 15, "description": "Insufficient supply" },
+                { "code": 16, "description": "Invalid count of field \"changes\"" },
+                { "code": 17, "description": "\"changes\" is empty." },
+                { "code": 18, "description": "Invalid field of \"changes\"" },
+                { "code": 19, "description": "Invalid field of \"changes\"" },
+                { "code": 20, "description": "Invalid \"meta\" length" },
+                { "code": 21, "description": "Supply for token reached maximum" },
+                { "code": 22, "description": "Approver is same as proxy." },
+                { "code": 23, "description": "Proxy isn't approved on the token." },
+                { "code": 24, "description": "Proxy is already approved on the token." }
+            ]
+        },
+        {
+            "codespace": "contract",
+            "codes": [
+                { "code": 0, "description": "" },
+                { "code": 1, "description": "Invalid contract ID" },
+                { "code": 2, "description": "Contract doesn't exist." }
+            ]
+        },
+        {
+            "codespace": "link",
+            "codes": [
+                { "code": 0, "description": "" },
+                { "code": 1, "description": "Error" },
+                { "code": 2, "description": "Invalid permission" },
+                { "code": 3, "description": "Invalid name" }
+            ]
+        },
+        {
+            "codespace": "sdk",
+            "codes": [
+                { "code": 0, "description": "" },
+                { "code": 2, "description": "Tx parse error" },
+                { "code": 3, "description": "Invalid sequence" },
+                { "code": 4, "description": "Unauthorized" },
+                { "code": 5, "description": "Insufficient funds" },
+                { "code": 6, "description": "Unknown request" },
+                { "code": 7, "description": "Invalid address" },
+                { "code": 8, "description": "Invalid public key" },
+                { "code": 9, "description": "Unknown address" },
+                { "code": 10, "description": "Invalid coins" },
+                { "code": 11, "description": "Out of gas" },
+                { "code": 12, "description": "Memo is too large." },
+                { "code": 13, "description": "Insufficient fee" },
+                { "code": 14, "description": "Maximum number of signatures exceeded." },
+                { "code": 15, "description": "No signatures supplied." },
+                { "code": 16, "description": "Failed to marshal JSON bytes." },
+                { "code": 17, "description": "Failed to unmarshal JSON bytes." },
+                { "code": 18, "description": "Invalid request" },
+                { "code": 19, "description": "Tx already in mempool." },
+                { "code": 20, "description": "Mempool is full." },
+                { "code": 21, "description": "Tx too large" }
+            ]
+        }
+    ];
+
+export class TxResultCode {
+    constructor(
+        readonly codeSpace: string,
+        readonly code: number,
+        readonly description: string,
+    ) { }
+    isSuccess(): boolean {
+        return this.code == 0
+    }
+    txResultType(): TxResultType {
+        if (this.isSuccess()) {
+            return TxResultType.SUCCESS
+        } else {
+            return TxResultType.FAIL
+        }
+    }
+
+    static invalidTxResultCode(): TxResultCode {
+        return new TxResultCode("invalid-name-space", -1, "invalid tx-result-code");
+    }
+}
+
+export enum TxResultType {
+    SUCCESS, FAIL
+}
+
+export class TxResultCodeMappingsProvider {
+    private static mappings: Array<any> = txResultCodeMappings
+    private constructor() { }
+
+    static codes(codespace: string): Array<TxResultCode> {
+        return this.mappings.filter(it => it.codespace == codespace)
+            .flatMap(it => it.codes)
+            .map(it => new TxResultCode(codespace, it.code, it.description))
+    }
+
+    static code(txResultResponse: TxResultResponse): TxResultCode {
+        const code = this.mappings.filter(it => it.codespace == txResultResponse.codespace)
+            .flatMap(it => it.codes)
+            .find(it => it.code = txResultResponse.code)
+
+        if (code) {
+            return new TxResultCode(code.codespace, code.code, code.description);
+        } else {
+            return TxResultCode.invalidTxResultCode();
+        }
+    }
+}

--- a/test/test-data.ts
+++ b/test/test-data.ts
@@ -2048,227 +2048,227 @@ export const nonFungibleTokenModifyTxResult = {
 };
 
 export const attachNFTTxResult =
-  // collection/MsgAttach
-  {
-    height: 199344,
-    txhash: "5F2C29B4A058CF21E858AF1890E1E76DA5F24F264975D768DC2E486BAC6B9422",
-    codespace: "",
-    code: 0,
-    index: 0,
-    data: "",
-    logs: [
-      {
-        msgIndex: 0,
-        log: "",
-        events: [
-          {
-            type: "attach",
-            attributes: [
-              {
-                key: "contract_id",
-                value: "61e14383",
-              },
-              {
-                key: "from",
-                value: "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
-              },
-              {
-                key: "to_token_id",
-                value: "100000080000000f",
-              },
-              {
-                key: "token_id",
-                value: "100000080000000e",
-              },
-              {
-                key: "old_root_token_id",
-                value: "100000080000000e",
-              },
-              {
-                key: "new_root_token_id",
-                value: "100000080000000f",
-              },
-            ],
-          },
-          {
-            type: "message",
-            attributes: [
-              {
-                key: "module",
-                value: "collection",
-              },
-              {
-                key: "sender",
-                value: "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
-              },
-              {
-                key: "action",
-                value: "attach",
-              },
-            ],
-          },
-          {
-            type: "operation_root_changed",
-            attributes: [
-              {
-                key: "token_id",
-                value: "100000080000000e",
-              },
-            ],
-          },
-        ],
-      },
-    ],
-    info: "",
-    gasWanted: 100000000,
-    gasUsed: 24438,
-    tx: {
-      type: "cosmos-sdk/StdTx",
-      value: {
-        msg: [
-          {
-            type: "collection/MsgAttach",
-            value: {
-              from: "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
-              contractId: "61e14383",
-              toTokenId: "100000080000000f",
-              tokenId: "100000080000000e",
+// collection/MsgAttach
+{
+  height: 199344,
+  txhash: "5F2C29B4A058CF21E858AF1890E1E76DA5F24F264975D768DC2E486BAC6B9422",
+  codespace: "",
+  code: 0,
+  index: 0,
+  data: "",
+  logs: [
+    {
+      msgIndex: 0,
+      log: "",
+      events: [
+        {
+          type: "attach",
+          attributes: [
+            {
+              key: "contract_id",
+              value: "61e14383",
             },
-          },
-        ],
-        fee: {
-          gas: 100000000,
-          amount: [],
+            {
+              key: "from",
+              value: "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+            },
+            {
+              key: "to_token_id",
+              value: "100000080000000f",
+            },
+            {
+              key: "token_id",
+              value: "100000080000000e",
+            },
+            {
+              key: "old_root_token_id",
+              value: "100000080000000e",
+            },
+            {
+              key: "new_root_token_id",
+              value: "100000080000000f",
+            },
+          ],
         },
-        memo: "",
-        signatures: [
-          {
-            pubKey: {
-              type: "tendermint/PubKeySecp256k1",
-              value: "A41pCdZ71Vw66K5er5JrzVqYffiZsjoLBDB2szrNIJjy",
+        {
+          type: "message",
+          attributes: [
+            {
+              key: "module",
+              value: "collection",
             },
-            signature:
-              "4MRKtMIK3gazQUzzGEMt2KnRuIWeSs1opwUjIxrsHLtdCOP+3M7v6lYN2E49//qthaNDNKOJQiJ5pQMZwmw9Jg==",
-          },
-        ],
-      },
+            {
+              key: "sender",
+              value: "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+            },
+            {
+              key: "action",
+              value: "attach",
+            },
+          ],
+        },
+        {
+          type: "operation_root_changed",
+          attributes: [
+            {
+              key: "token_id",
+              value: "100000080000000e",
+            },
+          ],
+        },
+      ],
     },
-    timestamp: 1618370726000,
-  };
+  ],
+  info: "",
+  gasWanted: 100000000,
+  gasUsed: 24438,
+  tx: {
+    type: "cosmos-sdk/StdTx",
+    value: {
+      msg: [
+        {
+          type: "collection/MsgAttach",
+          value: {
+            from: "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+            contractId: "61e14383",
+            toTokenId: "100000080000000f",
+            tokenId: "100000080000000e",
+          },
+        },
+      ],
+      fee: {
+        gas: 100000000,
+        amount: [],
+      },
+      memo: "",
+      signatures: [
+        {
+          pubKey: {
+            type: "tendermint/PubKeySecp256k1",
+            value: "A41pCdZ71Vw66K5er5JrzVqYffiZsjoLBDB2szrNIJjy",
+          },
+          signature:
+            "4MRKtMIK3gazQUzzGEMt2KnRuIWeSs1opwUjIxrsHLtdCOP+3M7v6lYN2E49//qthaNDNKOJQiJ5pQMZwmw9Jg==",
+        },
+      ],
+    },
+  },
+  timestamp: 1618370726000,
+};
 
 export const attachFromNFTTxResult =
-  // collection/MsgAttachFrom
-  {
-    height: 199366,
-    txhash: "C3A89E0DA50C9D73A9D0727970040504A49987D6789FC9B8B52C615749F58E06",
-    codespace: "",
-    code: 0,
-    index: 0,
-    data: "",
-    logs: [
-      {
-        msgIndex: 0,
-        log: "",
-        events: [
-          {
-            type: "attach_from",
-            attributes: [
-              {
-                key: "contract_id",
-                value: "61e14383",
-              },
-              {
-                key: "proxy",
-                value: "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
-              },
-              {
-                key: "from",
-                value: "tlink17dz3hqn6nd5j6euymaw3ft9phgspmuhfjqazph",
-              },
-              {
-                key: "to_token_id",
-                value: "100000010000000c",
-              },
-              {
-                key: "token_id",
-                value: "100000010000000b",
-              },
-              {
-                key: "old_root_token_id",
-                value: "100000010000000b",
-              },
-              {
-                key: "new_root_token_id",
-                value: "100000010000000c",
-              },
-            ],
-          },
-          {
-            type: "message",
-            attributes: [
-              {
-                key: "module",
-                value: "collection",
-              },
-              {
-                key: "sender",
-                value: "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
-              },
-              {
-                key: "action",
-                value: "attach_from",
-              },
-            ],
-          },
-          {
-            type: "operation_root_changed",
-            attributes: [
-              {
-                key: "token_id",
-                value: "100000010000000b",
-              },
-            ],
-          },
-        ],
-      },
-    ],
-    info: "",
-    gasWanted: 100000000,
-    gasUsed: 25583,
-    tx: {
-      type: "cosmos-sdk/StdTx",
-      value: {
-        msg: [
-          {
-            type: "collection/MsgAttachFrom",
-            value: {
-              proxy: "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
-              contractId: "61e14383",
-              from: "tlink17dz3hqn6nd5j6euymaw3ft9phgspmuhfjqazph",
-              toTokenId: "100000010000000c",
-              tokenId: "100000010000000b",
+// collection/MsgAttachFrom
+{
+  height: 199366,
+  txhash: "C3A89E0DA50C9D73A9D0727970040504A49987D6789FC9B8B52C615749F58E06",
+  codespace: "",
+  code: 0,
+  index: 0,
+  data: "",
+  logs: [
+    {
+      msgIndex: 0,
+      log: "",
+      events: [
+        {
+          type: "attach_from",
+          attributes: [
+            {
+              key: "contract_id",
+              value: "61e14383",
             },
-          },
-        ],
-        fee: {
-          gas: 100000000,
-          amount: [],
+            {
+              key: "proxy",
+              value: "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+            },
+            {
+              key: "from",
+              value: "tlink17dz3hqn6nd5j6euymaw3ft9phgspmuhfjqazph",
+            },
+            {
+              key: "to_token_id",
+              value: "100000010000000c",
+            },
+            {
+              key: "token_id",
+              value: "100000010000000b",
+            },
+            {
+              key: "old_root_token_id",
+              value: "100000010000000b",
+            },
+            {
+              key: "new_root_token_id",
+              value: "100000010000000c",
+            },
+          ],
         },
-        memo: "",
-        signatures: [
-          {
-            pubKey: {
-              type: "tendermint/PubKeySecp256k1",
-              value: "A41pCdZ71Vw66K5er5JrzVqYffiZsjoLBDB2szrNIJjy",
+        {
+          type: "message",
+          attributes: [
+            {
+              key: "module",
+              value: "collection",
             },
-            signature:
-              "pnuJr65omjGaVKX66GnK7O32nRLznhiBQTsW0+5muLVwbGO5AHWI2meUg63Z95pEz1YB/wAaHxdC57ocUr0t9A==",
-          },
-        ],
-      },
+            {
+              key: "sender",
+              value: "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+            },
+            {
+              key: "action",
+              value: "attach_from",
+            },
+          ],
+        },
+        {
+          type: "operation_root_changed",
+          attributes: [
+            {
+              key: "token_id",
+              value: "100000010000000b",
+            },
+          ],
+        },
+      ],
     },
-    timestamp: 1618370726000,
-  };
+  ],
+  info: "",
+  gasWanted: 100000000,
+  gasUsed: 25583,
+  tx: {
+    type: "cosmos-sdk/StdTx",
+    value: {
+      msg: [
+        {
+          type: "collection/MsgAttachFrom",
+          value: {
+            proxy: "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+            contractId: "61e14383",
+            from: "tlink17dz3hqn6nd5j6euymaw3ft9phgspmuhfjqazph",
+            toTokenId: "100000010000000c",
+            tokenId: "100000010000000b",
+          },
+        },
+      ],
+      fee: {
+        gas: 100000000,
+        amount: [],
+      },
+      memo: "",
+      signatures: [
+        {
+          pubKey: {
+            type: "tendermint/PubKeySecp256k1",
+            value: "A41pCdZ71Vw66K5er5JrzVqYffiZsjoLBDB2szrNIJjy",
+          },
+          signature:
+            "pnuJr65omjGaVKX66GnK7O32nRLznhiBQTsW0+5muLVwbGO5AHWI2meUg63Z95pEz1YB/wAaHxdC57ocUr0t9A==",
+        },
+      ],
+    },
+  },
+  timestamp: 1618370726000,
+};
 
 export const detachNFTTxResult = {
   height: 199446,
@@ -3015,201 +3015,201 @@ export const mintNonFungibleTxResult = {
 };
 
 export const burnNonFungibleTxResult =
-  // collection/MsgBurnNFT
-  {
-    height: 183737,
-    txhash: "40CBB20B0C78A61864184EF11F05EA2EDBB582D08700C7DFAE4AE5495D63BC56",
-    codespace: "",
-    code: 0,
-    index: 0,
-    data: "",
-    logs: [
-      {
-        msgIndex: 0,
-        log: "",
-        events: [
-          {
-            type: "burn_nft",
-            attributes: [
-              {
-                key: "contract_id",
-                value: "61e14383",
-              },
-              {
-                key: "from",
-                value: "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
-              },
-              {
-                key: "token_id",
-                value: "1000000100000003",
-              },
-            ],
-          },
-          {
-            type: "message",
-            attributes: [
-              {
-                key: "module",
-                value: "collection",
-              },
-              {
-                key: "sender",
-                value: "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
-              },
-              {
-                key: "action",
-                value: "burn_nft",
-              },
-            ],
-          },
-          {
-            type: "operation_burn_nft",
-            attributes: [
-              {
-                key: "token_id",
-                value: "1000000100000003",
-              },
-            ],
-          },
-        ],
-      },
-    ],
-    info: "",
-    gasWanted: 100000000,
-    gasUsed: 280717,
-    tx: {
-      type: "cosmos-sdk/StdTx",
-      value: {
-        msg: [
-          {
-            type: "collection/MsgBurnNFT",
-            value: {
-              from: "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
-              contractId: "61e14383",
-              tokenIds: ["1000000100000003"],
+// collection/MsgBurnNFT
+{
+  height: 183737,
+  txhash: "40CBB20B0C78A61864184EF11F05EA2EDBB582D08700C7DFAE4AE5495D63BC56",
+  codespace: "",
+  code: 0,
+  index: 0,
+  data: "",
+  logs: [
+    {
+      msgIndex: 0,
+      log: "",
+      events: [
+        {
+          type: "burn_nft",
+          attributes: [
+            {
+              key: "contract_id",
+              value: "61e14383",
             },
-          },
-        ],
-        fee: {
-          gas: 100000000,
-          amount: [],
+            {
+              key: "from",
+              value: "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+            },
+            {
+              key: "token_id",
+              value: "1000000100000003",
+            },
+          ],
         },
-        memo: "",
-        signatures: [
-          {
-            pubKey: {
-              type: "tendermint/PubKeySecp256k1",
-              value: "A41pCdZ71Vw66K5er5JrzVqYffiZsjoLBDB2szrNIJjy",
+        {
+          type: "message",
+          attributes: [
+            {
+              key: "module",
+              value: "collection",
             },
-            signature:
-              "eqWCFeKzSnJkTwq45JeUkjTPngofQNiRL0xMsvICv6QLb1o7fa8towGS/Vk02TY6Yh1c/JdP1flGp+9fZn+pFw==",
-          },
-        ],
-      },
+            {
+              key: "sender",
+              value: "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+            },
+            {
+              key: "action",
+              value: "burn_nft",
+            },
+          ],
+        },
+        {
+          type: "operation_burn_nft",
+          attributes: [
+            {
+              key: "token_id",
+              value: "1000000100000003",
+            },
+          ],
+        },
+      ],
     },
-    timestamp: 1618370726000,
-  };
+  ],
+  info: "",
+  gasWanted: 100000000,
+  gasUsed: 280717,
+  tx: {
+    type: "cosmos-sdk/StdTx",
+    value: {
+      msg: [
+        {
+          type: "collection/MsgBurnNFT",
+          value: {
+            from: "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+            contractId: "61e14383",
+            tokenIds: ["1000000100000003"],
+          },
+        },
+      ],
+      fee: {
+        gas: 100000000,
+        amount: [],
+      },
+      memo: "",
+      signatures: [
+        {
+          pubKey: {
+            type: "tendermint/PubKeySecp256k1",
+            value: "A41pCdZ71Vw66K5er5JrzVqYffiZsjoLBDB2szrNIJjy",
+          },
+          signature:
+            "eqWCFeKzSnJkTwq45JeUkjTPngofQNiRL0xMsvICv6QLb1o7fa8towGS/Vk02TY6Yh1c/JdP1flGp+9fZn+pFw==",
+        },
+      ],
+    },
+  },
+  timestamp: 1618370726000,
+};
 
 export const burnFromNonFungibleTxResult =
-  // collection/MsgBurnNFTFrom
-  {
-    height: 199298,
-    txhash: "5B4205FF4D039695053DDBA026AB007E20F62747C22C3A5F2A79A80BC993A91E",
-    codespace: "",
-    code: 0,
-    index: 0,
-    data: "",
-    logs: [
-      {
-        msgIndex: 0,
-        log: "",
-        events: [
-          {
-            type: "burn_nft_from",
-            attributes: [
-              {
-                key: "contract_id",
-                value: "61e14383",
-              },
-              {
-                key: "proxy",
-                value: "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
-              },
-              {
-                key: "from",
-                value: "tlink17dz3hqn6nd5j6euymaw3ft9phgspmuhfjqazph",
-              },
-              {
-                key: "token_id",
-                value: "1000000100000005",
-              },
-            ],
-          },
-          {
-            type: "message",
-            attributes: [
-              {
-                key: "module",
-                value: "collection",
-              },
-              {
-                key: "sender",
-                value: "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
-              },
-              {
-                key: "action",
-                value: "burn_nft_from",
-              },
-            ],
-          },
-          {
-            type: "operation_burn_nft",
-            attributes: [
-              {
-                key: "token_id",
-                value: "1000000100000005",
-              },
-            ],
-          },
-        ],
-      },
-    ],
-    info: "",
-    gasWanted: 100000000,
-    gasUsed: 357429,
-    tx: {
-      type: "cosmos-sdk/StdTx",
-      value: {
-        msg: [
-          {
-            type: "collection/MsgBurnNFTFrom",
-            value: {
-              proxy: "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
-              contractId: "61e14383",
-              from: "tlink17dz3hqn6nd5j6euymaw3ft9phgspmuhfjqazph",
-              tokenIds: ["1000000100000005"],
+// collection/MsgBurnNFTFrom
+{
+  height: 199298,
+  txhash: "5B4205FF4D039695053DDBA026AB007E20F62747C22C3A5F2A79A80BC993A91E",
+  codespace: "",
+  code: 0,
+  index: 0,
+  data: "",
+  logs: [
+    {
+      msgIndex: 0,
+      log: "",
+      events: [
+        {
+          type: "burn_nft_from",
+          attributes: [
+            {
+              key: "contract_id",
+              value: "61e14383",
             },
-          },
-        ],
-        fee: {
-          gas: 100000000,
-          amount: [],
+            {
+              key: "proxy",
+              value: "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+            },
+            {
+              key: "from",
+              value: "tlink17dz3hqn6nd5j6euymaw3ft9phgspmuhfjqazph",
+            },
+            {
+              key: "token_id",
+              value: "1000000100000005",
+            },
+          ],
         },
-        memo: "",
-        signatures: [
-          {
-            pubKey: {
-              type: "tendermint/PubKeySecp256k1",
-              value: "A41pCdZ71Vw66K5er5JrzVqYffiZsjoLBDB2szrNIJjy",
+        {
+          type: "message",
+          attributes: [
+            {
+              key: "module",
+              value: "collection",
             },
-            signature:
-              "Fd71AF+PmRWdGVg6Kgbdhnnyz0th/rKahzP0Yv9vrqVEtWD1WlCngrjRA23LVMVfEmULtGlKSy7Sac9Ni6+P6g==",
-          },
-        ],
-      },
+            {
+              key: "sender",
+              value: "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+            },
+            {
+              key: "action",
+              value: "burn_nft_from",
+            },
+          ],
+        },
+        {
+          type: "operation_burn_nft",
+          attributes: [
+            {
+              key: "token_id",
+              value: "1000000100000005",
+            },
+          ],
+        },
+      ],
     },
-    timestamp: 1618370726000,
-  };
+  ],
+  info: "",
+  gasWanted: 100000000,
+  gasUsed: 357429,
+  tx: {
+    type: "cosmos-sdk/StdTx",
+    value: {
+      msg: [
+        {
+          type: "collection/MsgBurnNFTFrom",
+          value: {
+            proxy: "tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq",
+            contractId: "61e14383",
+            from: "tlink17dz3hqn6nd5j6euymaw3ft9phgspmuhfjqazph",
+            tokenIds: ["1000000100000005"],
+          },
+        },
+      ],
+      fee: {
+        gas: 100000000,
+        amount: [],
+      },
+      memo: "",
+      signatures: [
+        {
+          pubKey: {
+            type: "tendermint/PubKeySecp256k1",
+            value: "A41pCdZ71Vw66K5er5JrzVqYffiZsjoLBDB2szrNIJjy",
+          },
+          signature:
+            "Fd71AF+PmRWdGVg6Kgbdhnnyz0th/rKahzP0Yv9vrqVEtWD1WlCngrjRA23LVMVfEmULtGlKSy7Sac9Ni6+P6g==",
+        },
+      ],
+    },
+  },
+  timestamp: 1618370726000,
+};
 
 export const multiMintNonFungibleTxResult = {
   height: 183068,
@@ -3620,4 +3620,50 @@ export const baseCoinTransferTxResult = {
     },
   },
   timestamp: 1618370726000,
+};
+
+export const failedTransferFromNonFungibleTxResult = {
+  height: 1449984,
+  txhash: "FEAA6D0A3CB0FDA43304AAA940B288BD7C513964F31502260D2815414C7893A4",
+  codespace: "collection",
+  code: 23,
+  index: 0,
+  data: "",
+  logs: [],
+  info: "",
+  gasWanted: 81355,
+  gasUsed: 66583,
+  tx: {
+    type: "cosmos-sdk/StdTx",
+    value: {
+      msg: [
+        {
+          type: "collection/MsgTransferNFTFrom",
+          value: {
+            proxy: "link1he0tp59u36mdjaw560gh8c27pz8fqms88l8nhu",
+            contractId: "bf365bab",
+            from: "link1j8jd9nps56txm2w3afcjsktrrjh0ft82eftchd",
+            to: "link137pmnn2snxdcwa5kmg5rra6u3tf2y5c7emmm7p",
+            tokenIds: ["100000010000000e", "100000010000000f"],
+          },
+        },
+      ],
+      fee: {
+        gas: 81355,
+        amount: [],
+      },
+      memo: "",
+      signatures: [
+        {
+          pubKey: {
+            type: "tendermint/PubKeySecp256k1",
+            value: "A0S7CghmtkRmFwe9lUAR3Jn+pjg53vRAhVtgP2nbg9J6",
+          },
+          signature:
+            "kfvIeTe0EzldPOZNC+cozhe741l5AZsJLOMaQ2jsEG9ARc0JzlpYe07WRqLP+AbVLGUvBxwLLw8/KIdpdW1R7g==",
+        },
+      ],
+    },
+  },
+  timestamp: 1618922069000,
 };

--- a/test/tx-result-code-mappings-prvider.spec.ts
+++ b/test/tx-result-code-mappings-prvider.spec.ts
@@ -1,0 +1,30 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { TxResultCodeMappingsProvider, TxResultType } from "../lib/tx-result-codes";
+import { transferFromNonFungibleTxResult, failedTransferFromNonFungibleTxResult } from "./test-data";
+
+
+describe("txResultMessageParserFactory-test", () => {
+    it("test get tx-result-codes", () => {
+        expect(false, TxResultCodeMappingsProvider.codes("bank")[0].isSuccess());
+        expect(TxResultType.FAIL, TxResultCodeMappingsProvider.codes("bank")[0].txResultType());
+        expect(1, TxResultCodeMappingsProvider.codes("bank")[0].code);
+        expect("No \"inputs\" for \"send\" type transaction", TxResultCodeMappingsProvider.codes("bank")[0].description);
+    });
+
+    it("test get tx-result-code from successful txResult", () => {
+        const txResultCode = TxResultCodeMappingsProvider.code(transferFromNonFungibleTxResult);
+        expect(true, txResultCode.isSuccess);
+        expect(TxResultType.SUCCESS, txResultCode.txResultType)
+        expect(0, txResultCode.code);
+        expect("", txResultCode.description);
+    });
+
+    it("test get tx-result-code from failed txResult", () => {
+        const txResultCode = TxResultCodeMappingsProvider.code(failedTransferFromNonFungibleTxResult);
+        expect(false, txResultCode.isSuccess);
+        expect(TxResultType.FAIL, txResultCode.txResultType)
+        expect(23, txResultCode.code);
+        expect("Token is being not owned.", txResultCode.description);
+    });
+});


### PR DESCRIPTION
### What kind of change does this PR introduce? 
* [O] feature

### What is the current behavior? 
There is no detail properties for `codespace`, `code` and description of a tx-result.

### What is the new behavior?
Resolve #43, so that we can provide details of result of transaction.

We can figure out a transaction is successful or failed like below.

```
it("test get tx-result-code from failed txResult", () => {
  const txResultCode = TxResultCodeMappingsProvider.code(failedTransferFromNonFungibleTxResult);
  expect(false, txResultCode.isSuccess);
  expect(TxResultType.FAIL, txResultCode.txResultType)
  expect(23, txResultCode.code);
  expect("Token is being not owned.", txResultCode.description);
});
```

### Other information
