### PR TITLE
feat: query proxy approvement of service, item-token

### DIFF
--- a/lib/http-client-base.ts
+++ b/lib/http-client-base.ts
@@ -38,6 +38,8 @@ import {
   CursorPaginatedNonFungibleBalanceWithTypes,
   IssuedServiceToken,
   CreatedItemToken,
+  ProxyApprovedResponse,
+  IssueProxyResponse,
 } from "./response";
 
 import {
@@ -897,15 +899,31 @@ export class HttpClient {
     return this.instance.post(path, request, requestTypeParam);
   }
 
+  public isServiceTokenProxyApproved(
+    userId: string,
+    contractId: string,
+  ): Promise<GenericResponse<ProxyApprovedResponse>> {
+    const path = `/v1/users/${userId}/service-tokens/${contractId}/proxy`;
+    return this.instance.get(path);
+  }
+
   public issueServiceTokenProxyRequest(
     userId: string,
     contractId: string,
     requestType: RequestType,
     request: UserProxyRequest,
-  ) {
+  ): Promise<GenericResponse<IssueProxyResponse>> {
     const path = `/v1/users/${userId}/service-tokens/${contractId}/request-proxy`;
     const requestTypeParam = this.requestTypeParam(requestType);
     return this.instance.post(path, request, requestTypeParam);
+  }
+
+  public isItemTokenProxyApproved(
+    userId: string,
+    contractId: string,
+  ): Promise<GenericResponse<ProxyApprovedResponse>> {
+    const path = `/v1/users/${userId}/item-tokens/${contractId}/proxy`;
+    return this.instance.get(path);
   }
 
   public issueItemTokenProxyRequest(
@@ -913,7 +931,7 @@ export class HttpClient {
     contractId: string,
     requestType: RequestType,
     request: UserProxyRequest,
-  ) {
+  ): Promise<GenericResponse<IssueProxyResponse>> {
     const path = `/v1/users/${userId}/item-tokens/${contractId}/request-proxy`;
     const requestTypeParam = this.requestTypeParam(requestType);
     return this.instance.post(path, request, requestTypeParam);

--- a/lib/response.ts
+++ b/lib/response.ts
@@ -372,3 +372,14 @@ export class SessionTokenResponse {
 export class RequestSessionStatus {
   constructor(readonly status: RequestSessionTokenStatus) { }
 }
+
+export class ProxyApprovedResponse {
+  constructor(readonly isApproved: boolean) { }
+}
+
+export class IssueProxyResponse {
+  constructor(
+    readonly requestSessionToken: string,
+    readonly redirectUri?: string
+  ) { }
+}

--- a/test/http-client-base.spec.ts
+++ b/test/http-client-base.spec.ts
@@ -3203,6 +3203,54 @@ describe("http-client-base test", () => {
       expect(error.message).to.equal("Invalid txHash - empty not allowed")
     }
   });
+
+  it("query proxy approvement of service-token", async () => {
+    const testContractId = "9636a07e";
+    const testUserId = "U556719f559479aab8b8f74c488bf6317";
+    const receivedData = {
+      responseTime: 1585467715136,
+      statusCode: 1000,
+      statusMessage: "Success",
+      responseData: {
+        isApproved: true,
+      }
+    };
+
+    stub = new MockAdapter(httpClient.getAxiosInstance());
+
+    stub.onGet(`/v1/users/${testUserId}/service-tokens/${testContractId}/proxy`).reply(config => {
+      assertHeaders(config.headers);
+      return [200, receivedData];
+    });
+
+    const response = await httpClient.isServiceTokenProxyApproved(testUserId, testContractId);
+    expect(response["statusCode"]).to.equal(1000);
+    expect(response["responseData"]["isApproved"]).to.equal(true);
+  });
+
+  it("query proxy approvement of item-token", async () => {
+    const testContractId = "9636a07e";
+    const testUserId = "U556719f559479aab8b8f74c488bf6317";
+    const receivedData = {
+      responseTime: 1585467715136,
+      statusCode: 1000,
+      statusMessage: "Success",
+      responseData: {
+        isApproved: true,
+      }
+    };
+
+    stub = new MockAdapter(httpClient.getAxiosInstance());
+
+    stub.onGet(`/v1/users/${testUserId}/item-tokens/${testContractId}/proxy`).reply(config => {
+      assertHeaders(config.headers);
+      return [200, receivedData];
+    });
+
+    const response = await httpClient.isItemTokenProxyApproved(testUserId, testContractId);
+    expect(response["statusCode"]).to.equal(1000);
+    expect(response["responseData"]["isApproved"]).to.equal(true);
+  });
 });
 
 function assertHeaders(headers: any) {


### PR DESCRIPTION
### What kind of change does this PR introduce? 
* [O ] feature

### What is the current behavior? 
There is no function to query proxy approval of a service or item token.

### What is the new behavior?
Resolve #41, functions to query proxy approval of a service or item token.
