### PR TITLE
fix: wrong path for refreshing thumbnails

### DIFF
--- a/lib/http-client-base.ts
+++ b/lib/http-client-base.ts
@@ -883,7 +883,7 @@ export class HttpClient {
     contractId: string,
     tokenTypes: Array<string>,
   ): Promise<GenericResponse<TokenMediaResourceUpdateResponse>> {
-    const path = `/v1/item-tokens/${contractId}/fungibles/thumbnail`;
+    const path = `/v1/item-tokens/${contractId}/fungibles/thumbnails`;
     const updateList = TokenType.fromMulti(tokenTypes);
     const request = new MultiFungibleTokenMediaResourcesUpdateRequest(
       updateList,
@@ -896,7 +896,7 @@ export class HttpClient {
     contractId: string,
     tokenIds: Array<string>,
   ): Promise<GenericResponse<TokenMediaResourceUpdateResponse>> {
-    const path = `/v1/item-tokens/${contractId}/non-fungibles/thumbnail`;
+    const path = `/v1/item-tokens/${contractId}/non-fungibles/thumbnails`;
     const updateList = TokenTypeAndIndex.fromMulti(tokenIds);
     const request = new MultiNonFungibleTokenMediaResourcesUpdateRequest(
       updateList,

--- a/test/http-client-base.spec.ts
+++ b/test/http-client-base.spec.ts
@@ -2791,7 +2791,7 @@ describe("http-client-base test", () => {
 
     stub = new MockAdapter(httpClient.getAxiosInstance());
 
-    const path = `/v1/item-tokens/${testContractId}/fungibles/thumbnail`;
+    const path = `/v1/item-tokens/${testContractId}/fungibles/thumbnails`;
     stub.onPut(path).reply(config => {
       assertHeaders(config.headers);
       expect(config.data).to.equal(JSON.stringify(expectedRequest));
@@ -2836,7 +2836,7 @@ describe("http-client-base test", () => {
 
     stub = new MockAdapter(httpClient.getAxiosInstance());
 
-    const path = `/v1/item-tokens/${testContractId}/non-fungibles/thumbnail`;
+    const path = `/v1/item-tokens/${testContractId}/non-fungibles/thumbnails`;
     stub.onPut(path).reply(config => {
       assertHeaders(config.headers);
       expect(config.data).to.equal(JSON.stringify(expectedRequest));


### PR DESCRIPTION
### What kind of change does this PR introduce? 
* [O] bug fix #53 

### What is the current behavior? 
Has wrong path for refreshing thumbnails

### What is the new behavior?
Correct path for refreshing thumbnails