### PR TITLE
fix: upgrade ts-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "nyc": "^15.1.0",
     "prettier": "^2.1.1",
     "ts-dotenv": "^0.8.3",
-    "ts-node": "^9.1.1",
+    "ts-node": "^10.8.1",
     "typescript": "^4.0.2"
   },
   "husky": {


### PR DESCRIPTION
### What kind of change does this PR introduce? 
* [O ] update

### What is the current behavior? 
Error from circle-ci like below.
```
Error: Debug Failure. False expression: Non-string value passed to `ts.resolveTypeReferenceDirective`, likely by a wrapping package working with an outdated `resolveTypeReferenceDirectives` signature. This is probably not a problem in TS itself.
```

### What is the new behavior?
I guess the error will be resolved, because upgrading to "ts-node": "10.8.1" is help us fix it.