### PR TITLE
fix: typo and add link to guide for tx-result adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,3 +229,7 @@ This class provides a functionality to [generate signatures](https://docs-blockc
 All API requests, except for the endpoint to retrieve the server time, must pass authentication information and be signed. Signing is a bit annoying, but never mind, fortunately, `HttpClient` itself will import this and generate signatures before sending a request. 
 
 If you do want to study how LINE Blockchain signature created, it's okay to dive into the source code.
+
+
+### New transaction result
+Please refer to [New transaction result](./docs/README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -251,7 +251,7 @@ const rawTransactionResultAdapter: TxResultAdapter<TxResultResponse, RawTransact
 const lbdTxResultAdapter: TxResultAdapter<RawTransactionResult, TxResult>  = new LbdTxEventsAdapterV1(HrpPrefix.TEST_NET);
 
 /*
-We can use custom adapters for summy, messages and events
+We can use custom adapters for summary, messages and events
 const customTxResultSummaryAdapter: TxResultAdapter<RawTransactionResult, TxResultSummary> = new CustomTxSummaryAdapterV1();
 const customTxMessagesAdapter: TxResultAdapter<RawTransactionResult, Set<TxMessage>>  = new CustomTxMessageAdapterV1();
 const customTxEventsAdapter: TxResultAdapter<RawTransactionResult, Set<TransactionEvent>>  = new CustomTxMessageAdapterV1();


### PR DESCRIPTION
### What kind of change does this PR introduce? 
* [ ] bug fix
* [ ] feature
* [x] docs
* [ ] update

### What is the current behavior? 
There was typo and no link to guide for tx-result adapters

