### PR TITLE
fix: sync properties name with actual response

### DIFF
--- a/lib/tx-core-models.ts
+++ b/lib/tx-core-models.ts
@@ -23,7 +23,7 @@ export class TxStatusResult {
     readonly code: number = 0,
     readonly codeSpace: string = "",
   ) {
-    if (this.code==0) {
+    if (this.code == 0) {
       this.result = TxSuccessResult.SUCCEEDED;
     } else {
       this.result = TxSuccessResult.FAILED;
@@ -54,8 +54,8 @@ export class TxResultSummary {
 export class TxResult {
   constructor(
     readonly summary: TxResultSummary,
-    readonly txMessages: Array<TxMessage>,
-    readonly txEvents: Array<TransactionEvent>,
+    readonly messages: Array<TxMessage>,
+    readonly events: Array<TransactionEvent>,
   ) {
   }
 
@@ -69,8 +69,8 @@ export class TxResult {
         "result": this.summary.result,
 
       },
-      "txMessages": [...this.txMessages],
-      "txEvents": [...this.txEvents],
+      "messages": [...this.messages],
+      "events": [...this.events],
     };
   }
 }

--- a/test/lbd-tx-result-adapter.spec.ts
+++ b/test/lbd-tx-result-adapter.spec.ts
@@ -24,9 +24,9 @@ describe("LbdTxResultAdapterV1 test", () => {
     expect(lbdTxResult.summary.txHash).to.equal(inputRawTxResult.txhash);
     expect(lbdTxResult.summary.txIndex).to.equal(inputRawTxResult.index);
     expect(lbdTxResult.summary.signers).to.deep.include(new TxSigner("tlink1fr9mpexk5yq3hu6jc0npajfsa0x7tl427fuveq"));
-    expect(lbdTxResult.txMessages).to.be.not.empty;
-    expect(lbdTxResult.txEvents).to.be.not.empty;
-    expect(_.first(Array.from(lbdTxResult.txEvents))["eventName"]).to.equal("EventCoinTransferred");
+    expect(lbdTxResult.messages).to.be.not.empty;
+    expect(lbdTxResult.events).to.be.not.empty;
+    expect(_.first(Array.from(lbdTxResult.events))["eventName"]).to.equal("EventCoinTransferred");
   });
 
   it("test createAccountTxResult", () => {
@@ -35,9 +35,9 @@ describe("LbdTxResultAdapterV1 test", () => {
     expect(lbdTxResult.summary.height).to.equal(inputRawTxResult.height);
     expect(lbdTxResult.summary.txHash).to.equal(inputRawTxResult.txhash);
     expect(lbdTxResult.summary.txIndex).to.equal(inputRawTxResult.index);
-    expect(lbdTxResult.txMessages).to.be.not.empty;
-    expect(lbdTxResult.txEvents).to.be.not.empty;
-    expect(_.first(Array.from(lbdTxResult.txEvents))["eventName"]).to.equal("EventAccountCreated");
+    expect(lbdTxResult.messages).to.be.not.empty;
+    expect(lbdTxResult.events).to.be.not.empty;
+    expect(_.first(Array.from(lbdTxResult.events))["eventName"]).to.equal("EventAccountCreated");
   });
 
   it("test accountMsgEmptyTxResult", () => {
@@ -46,9 +46,9 @@ describe("LbdTxResultAdapterV1 test", () => {
     expect(lbdTxResult.summary.height).to.equal(inputRawTxResult.height);
     expect(lbdTxResult.summary.txHash).to.equal(inputRawTxResult.txhash);
     expect(lbdTxResult.summary.txIndex).to.equal(inputRawTxResult.index);
-    expect(lbdTxResult.txMessages).to.be.not.empty;
-    expect(lbdTxResult.txEvents).to.be.not.empty;
-    expect(_.first(Array.from(lbdTxResult.txEvents))["eventName"]).to.equal("EventEmptyMsgCreated");
+    expect(lbdTxResult.messages).to.be.not.empty;
+    expect(lbdTxResult.events).to.be.not.empty;
+    expect(_.first(Array.from(lbdTxResult.events))["eventName"]).to.equal("EventEmptyMsgCreated");
   });
 });
 

--- a/test/tx-core-models.spec.ts
+++ b/test/tx-core-models.spec.ts
@@ -37,7 +37,7 @@ describe("core tx model tests", () => {
 
     let txResult = new TxResult(txResultSummary, [txMessage], [txEvent]);
 
-    let expectedTxResultJson = "{\"summary\":{\"height\":0,\"txIndex\":0,\"txHash\":\"D3833E2CED77A11639D03EC3DF4B0EC9B77EBFF48795B7151D5201439738031A\",\"signers\":[{\"address\":\"tlink145knu8tlpjmx9gsf0dxxfdcr68a4sapv5x6tk7\"}],\"result\":{\"code\":0,\"codeSpace\":\"\",\"result\":\"SUCCEEDED\"}},\"txMessages\":[{\"msgIndex\":0,\"requestType\":\"test\",\"details\":{\"key\":\"test\",\"value\":\"test value\"}}],\"txEvents\":[{\"eventName\":\"TestEvent\"}]}";
+    let expectedTxResultJson = "{\"summary\":{\"height\":0,\"txIndex\":0,\"txHash\":\"D3833E2CED77A11639D03EC3DF4B0EC9B77EBFF48795B7151D5201439738031A\",\"signers\":[{\"address\":\"tlink145knu8tlpjmx9gsf0dxxfdcr68a4sapv5x6tk7\"}],\"result\":{\"code\":0,\"codeSpace\":\"\",\"result\":\"SUCCEEDED\"}},\"messages\":[{\"msgIndex\":0,\"requestType\":\"test\",\"details\":{\"key\":\"test\",\"value\":\"test value\"}}],\"events\":[{\"eventName\":\"TestEvent\"}]}";
     expect(JSON.stringify(txResult.toJson())).to.equal(expectedTxResultJson);
   });
 });


### PR DESCRIPTION
### What kind of change does this PR introduce? 
* [x] bug fix
* [ ] feature
* [ ] docs
* [ ] update

### What is the current behavior? 
Fail to parse actual tx-result response from LBD

### What is the new behavior?
Update properties name 
* PTAL https://docs-blockchain.line.biz/api-guide/Callback-Response#transaction-result