### PR TITLE
fix: response type of attach nft function

### DIFF
--- a/lib/http-client-base.ts
+++ b/lib/http-client-base.ts
@@ -496,7 +496,7 @@ export class HttpClient {
     tokenType: string,
     tokenIndex: string,
     request: NonFungibleTokenAttachRequest,
-  ): Promise<GenericResponse<NonFungibleId>> {
+  ): Promise<GenericResponse<TxHashResponse>> {
     const path = `/v1/item-tokens/${contractId}/non-fungibles/${tokenType}/${tokenIndex}/parent`;
     return this.instance.post(path, request);
   }


### PR DESCRIPTION
### What kind of change does this PR introduce? 
* [x] bug fix
* [ ] feature
* [ ] docs
* [ ] update

### What is the current behavior? 
Defined wrong response type for `attachNonFungibleToken`

### What is the new behavior?
Fix with correct type