### PR TITLE
feat: make message details to empty

### DIFF
--- a/lib/tx-core-models.ts
+++ b/lib/tx-core-models.ts
@@ -16,7 +16,7 @@ export class TxMessage {
   ) {
   }
 
-  details: any = { }; // details are always empty.
+  readonly details: any = { }; // details are always empty.
 }
 
 export class TxStatusResult {

--- a/lib/tx-core-models.ts
+++ b/lib/tx-core-models.ts
@@ -13,9 +13,10 @@ export class TxMessage {
   constructor(
     readonly msgIndex: number,
     readonly requestType: string,
-    readonly details: any,
   ) {
   }
+
+  details: any = { }; // details are always empty.
 }
 
 export class TxStatusResult {

--- a/lib/tx-result-adapters.ts
+++ b/lib/tx-result-adapters.ts
@@ -19,7 +19,7 @@ import {
   RawTransactionRequestValue,
   RawTransactionResult,
   RawTransactionSignerAddressUtil,
-  RawTxSignature,
+  RawTxSignature
 } from "./tx-raw-models";
 
 import {
@@ -59,7 +59,7 @@ import {
   TxResultSummary,
   TxSigner,
   TxStatusResult,
-  UnknownTransactionEvent,
+  UnknownTransactionEvent
 } from "./tx-core-models";
 import { StringUtil } from "./string-util";
 import { TokenUtil } from "./token-util";
@@ -209,7 +209,7 @@ export class LbdTxMessageAdapterV1 implements TxResultAdapter<RawTransactionResu
     let rawMessages = tx.value.msg;
     let txMessages = _.map(rawMessages, (rawMessage, index) => {
       let type = rawMessage.type;
-      return new TxMessage(index, type, rawMessage.value);
+      return new TxMessage(index, type);
     });
     return txMessages;
   }

--- a/test/tx-core-models.spec.ts
+++ b/test/tx-core-models.spec.ts
@@ -2,12 +2,12 @@ import { expect } from "chai";
 import { describe, it } from "mocha";
 
 import {
-  TxMessage,
-  TxSigner,
-  TxStatusResult,
   TransactionEvent,
-  TxResultSummary,
+  TxMessage,
   TxResult,
+  TxResultSummary,
+  TxSigner,
+  TxStatusResult
 } from "../lib/tx-core-models";
 
 describe("core tx model tests", () => {
@@ -18,10 +18,6 @@ describe("core tx model tests", () => {
     let txMessage = new TxMessage(
       0,
       "test",
-      {
-        "key": "test",
-        "value": "test value",
-      },
     );
     let txEvent: TransactionEvent = {
       "eventName": "TestEvent",
@@ -37,7 +33,7 @@ describe("core tx model tests", () => {
 
     let txResult = new TxResult(txResultSummary, [txMessage], [txEvent]);
 
-    let expectedTxResultJson = "{\"summary\":{\"height\":0,\"txIndex\":0,\"txHash\":\"D3833E2CED77A11639D03EC3DF4B0EC9B77EBFF48795B7151D5201439738031A\",\"signers\":[{\"address\":\"tlink145knu8tlpjmx9gsf0dxxfdcr68a4sapv5x6tk7\"}],\"result\":{\"code\":0,\"codeSpace\":\"\",\"result\":\"SUCCEEDED\"}},\"txMessages\":[{\"msgIndex\":0,\"requestType\":\"test\",\"details\":{\"key\":\"test\",\"value\":\"test value\"}}],\"txEvents\":[{\"eventName\":\"TestEvent\"}]}";
+    let expectedTxResultJson = "{\"summary\":{\"height\":0,\"txIndex\":0,\"txHash\":\"D3833E2CED77A11639D03EC3DF4B0EC9B77EBFF48795B7151D5201439738031A\",\"signers\":[{\"address\":\"tlink145knu8tlpjmx9gsf0dxxfdcr68a4sapv5x6tk7\"}],\"result\":{\"code\":0,\"codeSpace\":\"\",\"result\":\"SUCCEEDED\"}},\"txMessages\":[{\"msgIndex\":0,\"requestType\":\"test\",\"details\":{}}],\"txEvents\":[{\"eventName\":\"TestEvent\"}]}";
     expect(JSON.stringify(txResult.toJson())).to.equal(expectedTxResultJson);
   });
 });


### PR DESCRIPTION
### What kind of change does this PR introduce? 
* [ ] bug fix
* [x] feature
* [ ] docs
* [ ] update

### What is the current behavior? 
Message details no longer give data

### What is the new behavior?
Make message details to empty

### Other information
