### PR TITLE
feat: new API to query nft holders v2

### DIFF
--- a/lib/http-client-base.ts
+++ b/lib/http-client-base.ts
@@ -442,10 +442,10 @@ export class HttpClient {
   public nonFungibleTokenTypeHoldersV2(
     contractId: string,
     tokenType: string,
-    pageRequest: PageRequest,
+    cursorPageRequest: CursorPageRequest,
     ): Promise<GenericResponse<Array<NonFungibleTokenTypeHolder>>> {
     const path = `/v2/item-tokens/${contractId}/non-fungibles/${tokenType}/holders`;
-    const requestConfig = this.pageRequestConfig(pageRequest);
+    const requestConfig = this.pageRequestConfig(cursorPageRequest);
     return this.instance.get(path, requestConfig);
   }
 

--- a/lib/http-client-base.ts
+++ b/lib/http-client-base.ts
@@ -41,7 +41,8 @@ import {
   CreatedItemToken,
   ProxyApprovedResponse,
   IssueProxyResponse,
-  UserRequestStatus, NonFungibleTokenTypeHolderList,
+  UserRequestStatus,
+  NonFungibleTokenTypeHolderList,
 } from "./response";
 
 import {

--- a/lib/http-client-base.ts
+++ b/lib/http-client-base.ts
@@ -41,7 +41,7 @@ import {
   CreatedItemToken,
   ProxyApprovedResponse,
   IssueProxyResponse,
-  UserRequestStatus,
+  UserRequestStatus, NonFungibleTokenTypeHolderList,
 } from "./response";
 
 import {
@@ -443,9 +443,9 @@ export class HttpClient {
     contractId: string,
     tokenType: string,
     cursorPageRequest: CursorPageRequest,
-    ): Promise<GenericResponse<Array<NonFungibleTokenTypeHolder>>> {
+    ): Promise<GenericResponse<NonFungibleTokenTypeHolderList>> {
     const path = `/v2/item-tokens/${contractId}/non-fungibles/${tokenType}/holders`;
-    const requestConfig = this.pageRequestConfig(cursorPageRequest);
+    const requestConfig = this.cursorPageRequestConfig(cursorPageRequest);
     return this.instance.get(path, requestConfig);
   }
 

--- a/lib/http-client-base.ts
+++ b/lib/http-client-base.ts
@@ -435,6 +435,20 @@ export class HttpClient {
     return this.instance.get(path, requestConfig);
   }
 
+  /**
+    ** Caution **
+    The list of holders in the response is not sorted by "amount", but this is much faster then previous one
+  */
+  public nonFungibleTokenTypeHoldersV2(
+    contractId: string,
+    tokenType: string,
+    pageRequest: PageRequest,
+    ): Promise<GenericResponse<Array<NonFungibleTokenTypeHolder>>> {
+    const path = `/v2/item-tokens/${contractId}/non-fungibles/${tokenType}/holders`;
+    const requestConfig = this.pageRequestConfig(pageRequest);
+    return this.instance.get(path, requestConfig);
+  }
+
   // NFT has to belong to only one holder
   public nonFungibleTokenHolder(
     contractId: string,

--- a/lib/response.ts
+++ b/lib/response.ts
@@ -350,6 +350,14 @@ export class NonFungibleTokenTypeHolder {
   ) { }
 }
 
+export class NonFungibleTokenTypeHolderList {
+  constructor(
+    readonly list: Array<NonFungibleTokenTypeHolder>,
+    readonly prePageToken: string,
+    readonly nextPageToken: string,
+    ) { }
+}
+
 export class NonFungibleTokenHolder {
   constructor(
     readonly tokenId: string,


### PR DESCRIPTION
### What kind of change does this PR introduce? 
* [ ] bug fix
* [ ] feature
* [ ] docs
* [ ] update

### What is the current behavior? 
[Current API to query holders of NFTs of a specific type](https://docs-blockchain.line.biz/api-guide/category-item-tokens/retrieve#v1-item-tokens-contractId-non-fungibles-tokenType-holders-get) is a kind of slow, so there will be new API that faster than the [current API](https://docs-blockchain.line.biz/api-guide/category-item-tokens/retrieve#v1-item-tokens-contractId-non-fungibles-tokenType-holders-get)

### What is the new behavior?
New function for the new API